### PR TITLE
reset customerID to null once LOGOUT command has been issued.

### DIFF
--- a/newbank/server/NewBankClientHandler.java
+++ b/newbank/server/NewBankClientHandler.java
@@ -60,6 +60,7 @@ public class NewBankClientHandler extends Thread{
 						out.println(response);
 						if (response.equals(Constants.logoutResponse)) {
 							loggedIn = false;
+							this.customer = null;
 						}
 					}
 				} else {


### PR DESCRIPTION
customerID was retained after logging out, cause the login loop to be able to run when it shouldn't have.
https://trello.com/c/OLi2wYzb/46-fix-bug-typing-in-customer-name-on-start-up-and-then-typing-login-causes-null-error